### PR TITLE
Fix router semicolon

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -47,11 +47,11 @@ $router->add('POST', '/admin/category/delete', fn() => (new AdminCategoryControl
 /* GraphLine */
 $router->add('GET', '/graph/inLine-data', fn() => (new GraphLineController)->incomeLine());
 $router->add('GET', '/graph/exLine-data', fn() => (new GraphLineController)->expenditureLine());
-$router->add('GET', '/graph/line',        fn() => (new GraphLineController)->view());;
+$router->add('GET', '/graph/line',        fn() => (new GraphLineController)->view());
 /* GraphCircle */
 $router->add('GET', '/graph/inCircle-data', fn() => (new GraphCircleController)->incomeCircle());
 $router->add('GET', '/graph/exCircle-data', fn() => (new GraphCircleController)->expenditureCircle());
-$router->add('GET', '/graph/circle',        fn() => (new GraphCircleController)->view());;
+$router->add('GET', '/graph/circle',        fn() => (new GraphCircleController)->view());
 
 
 /* ---------- 発射 ---------- */


### PR DESCRIPTION
## Summary
- remove redundant semicolons in `/graph/line` and `/graph/circle` routes

## Testing
- `php -l public/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684108188f9c832cb14aa45fae61c36b